### PR TITLE
Fix resource update for 'awx_credential' 

### DIFF
--- a/docs/resources/credential.md
+++ b/docs/resources/credential.md
@@ -17,14 +17,14 @@ resource "awx_organization" "example" {
   name = "example"
 }
 
-resource "awx_credential_machine" "example" {
-  name            = "example"
-  description     = "Example Machine Credential"
-  organization_id = awx_organization.example.id
-  credential_type = "Machine"
+resource "awx_credential" "example" {
+  name               = "example"
+  description        = "Example of ansible vault credential"
+  organization_id    = awx_organization.example.id
+  credential_type_id = 3 # ansible vault
   inputs = {
-    username = "admin"
-    password = "password"
+    vault_password = "admin"
+    vault_id       = "password"
   }
 }
 ```
@@ -35,7 +35,7 @@ resource "awx_credential_machine" "example" {
 ### Required
 
 - `credential_type_id` (Number) Specify the type of credential you want to create. Refer to the Ansible Tower documentation for details on each type
-- `inputs` (String, Sensitive) The inputs to be created with the credential.
+- `inputs` (Map of String, Sensitive) The inputs to be created with the credential.
 - `name` (String) The name of the credential
 - `organization_id` (Number) The organization ID that the credential belongs to
 

--- a/examples/resources/awx_credential/resource.tf
+++ b/examples/resources/awx_credential/resource.tf
@@ -2,13 +2,13 @@ resource "awx_organization" "example" {
   name = "example"
 }
 
-resource "awx_credential_machine" "example" {
-  name            = "example"
-  description     = "Example Machine Credential"
-  organization_id = awx_organization.example.id
-  credential_type = "Machine"
+resource "awx_credential" "example" {
+  name               = "example"
+  description        = "Example of ansible vault credential"
+  organization_id    = awx_organization.example.id
+  credential_type_id = 3 # ansible vault
   inputs = {
-    username = "admin"
-    password = "password"
+    vault_password = "admin"
+    vault_id       = "password"
   }
 }

--- a/internal/awx/resource_credential.go
+++ b/internal/awx/resource_credential.go
@@ -2,7 +2,6 @@ package awx
 
 import (
 	"context"
-	"encoding/json"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -42,7 +41,7 @@ func resourceCredential() *schema.Resource {
 				Description: "Specify the type of credential you want to create. Refer to the Ansible Tower documentation for details on each type",
 			},
 			"inputs": {
-				Type:        schema.TypeString,
+				Type:        schema.TypeMap,
 				Required:    true,
 				Sensitive:   true,
 				Description: "The inputs to be created with the credential.",
@@ -52,11 +51,7 @@ func resourceCredential() *schema.Resource {
 }
 
 func resourceCredentialCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	inputs := d.Get("inputs").(string)
-	inputsMap := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(inputs), &inputsMap); err != nil {
-		return utils.DiagCreate(diagCredentialTitle, err)
-	}
+	inputsMap := d.Get("inputs")
 
 	payload := map[string]interface{}{
 		"name":            d.Get("name").(string),
@@ -115,11 +110,7 @@ func resourceCredentialUpdate(ctx context.Context, d *schema.ResourceData, m int
 	if d.HasChanges(keys...) {
 		var err error
 
-		inputs := d.Get("inputs").(string)
-		inputsMap := make(map[string]interface{})
-		if err := json.Unmarshal([]byte(inputs), &inputsMap); err != nil {
-			return utils.DiagUpdate(diagCredentialTitle, d.Id(), err)
-		}
+		inputsMap := d.Get("inputs")
 
 		id, err := strconv.Atoi(d.Id())
 		if err != nil {
@@ -139,7 +130,7 @@ func resourceCredentialUpdate(ctx context.Context, d *schema.ResourceData, m int
 		}
 	}
 
-	return resourceCredentialSCMRead(ctx, d, m)
+	return resourceCredentialRead(ctx, d, m)
 }
 
 func resourceCredentialDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {


### PR DESCRIPTION
There was bug with resource 'awx_credential' with field 'inputs'. 
AWX credential has field 'inputs' and it's type string, but in the rest api documentation has type JSON. 

**Issue**:
  After apply terraform state for awx_credential with already created resources, failed because AWX api returned value for 'inputs' with type 'map[string]interface{}'. 
 
**Changed**:
- type for 'inputs' field, from string to map[string]interface{}
- removed unmarshal  for 'inputs' field

**Fixed:**
- used correct return function in 'resourceCredentialUpdate', changed from 'resourceCredentialSCMRead' to 'resourceCredentialRead'