### PR TITLE
Can not create an organization without default_environment

### DIFF
--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -28,7 +28,7 @@ resource "awx_organization" "example" {
 ### Optional
 
 - `custom_virtualenv` (String) Local absolute file path containing a custom Python virtualenv to use
-- `default_environment` (Number) The default execution environment for jobs run by this organization.
+- `default_environment` (String) The default execution environment for jobs run by this organization.
 - `description` (String) The description of the organization
 - `max_hosts` (Number) Maximum number of hosts allowed to be managed by this organization
 

--- a/internal/awx/resource_organization.go
+++ b/internal/awx/resource_organization.go
@@ -43,9 +43,9 @@ func resourceOrganization() *schema.Resource {
 				Description: "Local absolute file path containing a custom Python virtualenv to use",
 			},
 			"default_environment": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     0,
+				Default:     "",
 				Description: "The default execution environment for jobs run by this organization.",
 			},
 		},
@@ -68,7 +68,7 @@ func resourceOrganizationsCreate(ctx context.Context, d *schema.ResourceData, m 
 		"description":         d.Get("description").(string),
 		"max_hosts":           d.Get("max_hosts").(int),
 		"custom_virtualenv":   d.Get("description").(string),
-		"default_environment": d.Get("default_environment").(int),
+		"default_environment": d.Get("default_environment").(string),
 	}, map[string]string{})
 	if err != nil {
 		return utils.DiagCreate(diagOrganizationTitle, err)
@@ -95,7 +95,7 @@ func resourceOrganizationsUpdate(ctx context.Context, d *schema.ResourceData, m 
 		"description":         d.Get("description").(string),
 		"max_hosts":           d.Get("max_hosts").(int),
 		"custom_virtualenv":   d.Get("description").(string),
-		"default_environment": d.Get("default_environment").(int),
+		"default_environment": d.Get("default_environment").(string),
 	}, map[string]string{}); err != nil {
 		return utils.DiagUpdate(diagOrganizationTitle, id, err)
 	}


### PR DESCRIPTION
`default_environment` is an optional argument of resource `awx_organization`. However if you don't set the variable, the provider still tries to associate the environment with `id=0` to the organization, which result in a fail if it does not exist.

```
  # awx_organization.orga will be created
  + resource "awx_organization" "orga" {
      + id        = (known after apply)
      + max_hosts = 0
      + name      = "Organization name"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

awx_organization.orga: Creating...
╷
│ Error: Unable to create Organization
│ 
│   with awx_organization.orga,
│   on organizations.tf line 1, in resource "awx_organization" "orga":
│    1: resource "awx_organization" "orga" {
│ 
│ Unable to create Organization got Errors:
│ - default_environment: [Invalid pk "0" - object does not exist.]
```