### PR TITLE
Fixing credential type permadiff with json content for inputs/injectors

### DIFF
--- a/internal/awx/resource_credential_type.go
+++ b/internal/awx/resource_credential_type.go
@@ -1,14 +1,14 @@
 package awx
 
 import (
-    "context"
-    "encoding/json"
-    "strconv"
+	"context"
+	"encoding/json"
+	"strconv"
 
-    "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-    awx "github.com/josh-silvas/terraform-provider-awx/tools/goawx"
-    "github.com/josh-silvas/terraform-provider-awx/tools/utils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	awx "github.com/josh-silvas/terraform-provider-awx/tools/goawx"
+	"github.com/josh-silvas/terraform-provider-awx/tools/utils"
 )
 
 func resourceCredentialType() *schema.Resource {
@@ -103,17 +103,17 @@ func resourceCredentialTypeRead(_ context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-    inputsBytes, err := json.Marshal(credType.Inputs)
-    if err != nil {
-        return diag.FromErr(err)
-    }
-    injectorBytes, err := json.Marshal(credType.Injectors)
-    if err != nil {
-        return diag.FromErr(err)
-    }
+	inputsBytes, err := json.Marshal(credType.Inputs)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	injectorBytes, err := json.Marshal(credType.Injectors)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if err := d.Set("inputs", string(inputsBytes)); err != nil {
-        return diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 	if err := d.Set("injectors", string(injectorBytes)); err != nil {
 		return diag.FromErr(err)

--- a/internal/awx/resource_credential_type.go
+++ b/internal/awx/resource_credential_type.go
@@ -1,14 +1,14 @@
 package awx
 
 import (
-	"context"
-	"encoding/json"
-	"strconv"
+    "context"
+    "encoding/json"
+    "strconv"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	awx "github.com/josh-silvas/terraform-provider-awx/tools/goawx"
-	"github.com/josh-silvas/terraform-provider-awx/tools/utils"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+    awx "github.com/josh-silvas/terraform-provider-awx/tools/goawx"
+    "github.com/josh-silvas/terraform-provider-awx/tools/utils"
 )
 
 func resourceCredentialType() *schema.Resource {
@@ -102,10 +102,20 @@ func resourceCredentialTypeRead(_ context.Context, d *schema.ResourceData, m int
 	if err := d.Set("kind", credType.Kind); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("inputs", credType.Inputs); err != nil {
-		return diag.FromErr(err)
+
+    inputsBytes, err := json.Marshal(credType.Inputs)
+    if err != nil {
+        return diag.FromErr(err)
+    }
+    injectorBytes, err := json.Marshal(credType.Injectors)
+    if err != nil {
+        return diag.FromErr(err)
+    }
+
+	if err := d.Set("inputs", string(inputsBytes)); err != nil {
+        return diag.FromErr(err)
 	}
-	if err := d.Set("injectors", credType.Injectors); err != nil {
+	if err := d.Set("injectors", string(injectorBytes)); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
Hello,
I am having an error while updating credential types for inputs and injectors fields (JSON as string). The creation work but then the update was failing. I managed to make it work with this piece of code.

```
Error: inputs: '' expected type 'string', got unconvertible type 'map[string]interface {}', value: 'map[fields:[map[<content of the JSON>]'
```

However I still have a permadiff with "white space changes" on the JSON. 

The permadiff is gone by using this trick of encode/decode on the resource call side, but it's a bit ugly.
```
resource "awx_credential_type" "xxxxx" {
  name        = "Cred type name"
  description = "cred type description"
  inputs      = jsonencode(jsondecode(file("./files/credential_type_xxxx/inputs.json")))
  injectors   = jsonencode(jsondecode(file("./files/credential_type_xxxx/injectors.json")))
}
``` 

If anyone has some advice on how to fix this. Anyway, at least this PR fixes the update of credential types.
 
Thanks  