### PR TITLE
Add credential id in instance group

### DIFF
--- a/docs/resources/instance_group.md
+++ b/docs/resources/instance_group.md
@@ -49,6 +49,7 @@ resource "awx_instance_group" "example" {
 
 ### Optional
 
+- `credential_id` (String) ID of the credential of type 'OpenShift or Kubernetes API Bearer Token' to use as remote cluster.
 - `is_container_group` (Boolean) Whether the instance group is a container group.
 - `pod_spec_override` (String) The pod spec override for the instance group.
 - `policy_instance_minimum` (Number) The minimum number of instances to run in the instance group.

--- a/internal/awx/resource_instance_group.go
+++ b/internal/awx/resource_instance_group.go
@@ -52,6 +52,13 @@ func resourceInstanceGroup() *schema.Resource {
 				StateFunc:   utils.Normalize,
 				Description: "The pod spec override for the instance group.",
 			},
+			"credential_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				StateFunc:   utils.Normalize,
+				Description: "ID of the credential of type 'OpenShift or Kubernetes API Bearer Token' to use as remote cluster.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -70,6 +77,7 @@ func resourceInstanceGroupCreate(ctx context.Context, d *schema.ResourceData, m 
 		"is_container_group":         d.Get("is_container_group").(bool),
 		"policy_instance_percentage": d.Get("policy_instance_percentage").(int),
 		"pod_spec_override":          d.Get("pod_spec_override").(string),
+		"credential":                 d.Get("credential_id").(string),
 	}, map[string]string{})
 	if err != nil {
 		return utils.DiagCreate(diagInstanceGroupTitle, err)
@@ -93,6 +101,7 @@ func resourceInstanceGroupUpdate(ctx context.Context, d *schema.ResourceData, m 
 		"is_container_group":         d.Get("is_container_group").(bool),
 		"policy_instance_percentage": d.Get("policy_instance_percentage").(int),
 		"pod_spec_override":          d.Get("pod_spec_override").(string),
+		"credential":                 d.Get("credential_id").(string),
 	}, nil); err != nil {
 		return utils.DiagUpdate(diagInstanceGroupTitle, id, err)
 	}

--- a/tools/goawx/types.go
+++ b/tools/goawx/types.go
@@ -329,13 +329,12 @@ type UnifiedJobTemplate struct {
 
 // InstanceGroup represents the awx api instance group.
 type InstanceGroup struct {
-	ID               int      `json:"id"`
-	Instances        []string `json:"instances"`
-	Capacity         int      `json:"capacity"`
-	CredentialID     int      `json:"credential_id"` //nolint:golint,stylecheck
-	Name             string   `json:"name"`
-	IsContainerGroup bool     `json:"is_container_group"`
-	PodSpecOverride  string   `json:"pod_spec_override"`
+	ID               int    `json:"id"`
+	Capacity         int    `json:"capacity"`
+	CredentialID     int    `json:"credential"` //nolint:golint,stylecheck
+	Name             string `json:"name"`
+	IsContainerGroup bool   `json:"is_container_group"`
+	PodSpecOverride  string `json:"pod_spec_override"`
 }
 
 // Result data type.


### PR DESCRIPTION
Hello,
Added the possibility to specify a `credential_id` referring to a Kubernetes or OpenShift credential to create `ContainerGroup`. 

Also I removed the `instances` field from the types in goawx because: 
1. the AWX API says it's a 'field' (aka ManyToMany object in Django) but really all I've seen in my AWX instances is an integer (the number of instances in the group) and thus there is a conflict between the type int returned by the API and the type in the goawx (which would need big refactor, don't really know how to manage this).
2. It's not a field that can be updated via the API endpoint "instance_groups" but rather with the "instance_groups/id/instances", and it's not an information used/needed when managing instance_groups via the provider for now.

Thanks