### PR TITLE
Fix Job.Credential type

### DIFF
--- a/internal/awx/resource_project.go
+++ b/internal/awx/resource_project.go
@@ -227,15 +227,22 @@ func resourceProjectDelete(_ context.Context, d *schema.ResourceData, m interfac
 	if jobID != 0 {
 		if _, err = client.ProjectUpdatesService.ProjectUpdateCancel(jobID); err != nil {
 			return utils.Diagf(
-				"Delete: Fail to canel Job",
-				"Fail to canel the Job %v for Project with ID %v, got %s",
+				"Delete: Failed to cancel Job",
+				"Failed to cancel the Job %v for Project with ID %v, got %s",
 				jobID, id, err,
 			)
 		}
 	}
 	// check if finished is 0
 	for finished.IsZero() {
-		prj, _ := client.ProjectUpdatesService.ProjectUpdateGet(jobID)
+		prj, err := client.ProjectUpdatesService.ProjectUpdateGet(jobID)
+		if err != nil {
+			return utils.Diagf(
+				"Delete: failed to update project job",
+				"Failed to refresh job status for job %v of project %v, got %s",
+				jobID, id, err,
+			)
+		}
 		finished = prj.Finished
 		time.Sleep(1 * time.Second)
 	}

--- a/tools/goawx/types.go
+++ b/tools/goawx/types.go
@@ -538,7 +538,7 @@ type Job struct {
 	ScmRevision             string            `json:"scm_revision"`
 	InstanceGroup           int               `json:"instance_group"`
 	DiffMode                bool              `json:"diff_mode"`
-	Credential              *Credential       `json:"credential"`
+	Credential              int               `json:"credential"`
 	VaultCredential         interface{}       `json:"vault_credential"`
 }
 


### PR DESCRIPTION
I experienced the following error message when deleting projects which require a "source control" credential.
```
Stack trace from the terraform-provider-awx_v1.2.1 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x178 pc=0xb454ce]

goroutine 31 [running]:
github.com/josh-silvas/terraform-provider-awx/internal/awx.resourceProjectDelete({0xe263b0?, 0xc0000ad530?}, 0x0?, {0xba0860?, 0xc000512c00})
	github.com/josh-silvas/terraform-provider-awx/internal/awx/resource_project.go:239 +0x44e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).delete(0xc0003aaa80, {0xe263b0, 0xc0000ad530}, 0xd?, {0xba0860, 0xc000512c00})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/helper/schema/resource.go:829 +0x11b
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0003aaa80, {0xe263b0, 0xc0000ad530}, 0xc0000b08f0, 0xc000426300, {0xba0860, 0xc000512c00})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/helper/schema/resource.go:878 +0x605
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000396228, {0xe263b0?, 0xc0000ad440?}, 0xc000252c30)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/helper/schema/grpc_provider.go:1072 +0xdbc
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc00025efa0, {0xe263b0?, 0xc0000ac9c0?}, 0xc00049a070)
	github.com/hashicorp/terraform-plugin-go@v0.22.1/tfprotov5/tf5server/server.go:846 +0x3d0
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xcc9d80?, 0xc00025efa0}, {0xe263b0, 0xc0000ac9c0}, 0xc000426000, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.22.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:518 +0x169
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001b5000, {0xe263b0, 0xc0000ac900}, {0xe2a4e0, 0xc000007ba0}, 0xc000456fc0, 0xc0003a2d20, 0x1364358, 0x0)
	google.golang.org/grpc@v1.62.1/server.go:1386 +0xe23
google.golang.org/grpc.(*Server).handleStream(0xc0001b5000, {0xe2a4e0, 0xc000007ba0}, 0xc000456fc0)
	google.golang.org/grpc@v1.62.1/server.go:1797 +0x100c
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.62.1/server.go:1027 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 11
	google.golang.org/grpc@v1.62.1/server.go:1038 +0x135

Error: The terraform-provider-awx_v1.2.1 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

while debugging this, i noticed, that there's some error handling missing on the return values of `client.ProjectUpdatesService.ProjectUpdateGet`.
Adding this error handling exposed the underlying issue that `Job.Credential` is an `int`.