### PR TITLE
fix: surface the real API error on auth failure

### DIFF
--- a/internal/awx/provider.go
+++ b/internal/awx/provider.go
@@ -227,7 +227,7 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create AWX client",
-			Detail:   "Unable to auth user against AWX API: check the hostname, username and password",
+			Detail:   fmt.Sprintf("Unable to auth user against AWX API (check the hostname, username and password): %s", err),
 		})
 		return nil, diags
 	}

--- a/tools/goawx/awx.go
+++ b/tools/goawx/awx.go
@@ -1,9 +1,13 @@
 package awx
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 )
+
+const maxErrorBodyLen = 2048
 
 // This variable is mandatory and to be populated for creating services API.
 //
@@ -60,7 +64,26 @@ func CheckResponse(resp *http.Response) error {
 		return nil
 	}
 
-	return fmt.Errorf("responsed with %d, resp: %v", resp.StatusCode, resp)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		body = nil
+	}
+
+	return HTTPError(resp.StatusCode, body)
+}
+
+// HTTPError builds an error carrying the http status and the response body.
+func HTTPError(statusCode int, body []byte) error {
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		return fmt.Errorf("responded with %d %s", statusCode, http.StatusText(statusCode))
+	}
+
+	if len(body) > maxErrorBodyLen {
+		body = append(body[:maxErrorBodyLen:maxErrorBodyLen], []byte("... (truncated)")...)
+	}
+
+	return fmt.Errorf("responded with %d %s: %s", statusCode, http.StatusText(statusCode), body)
 }
 
 // ValidateParams is to validate the input to use the services.

--- a/tools/goawx/request.go
+++ b/tools/goawx/request.go
@@ -1,6 +1,7 @@
 package awx
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -110,21 +111,30 @@ func (r *Requester) Do(ar *APIRequest, responseStruct interface{}, options ...in
 		return nil, fmt.Errorf("Do.Request: %v", err)
 	}
 
-	//nolint:gomnd
-	if response.StatusCode == 400 { // Bad Request
-		var errorString string
+	if response.StatusCode >= http.StatusBadRequest {
+		body, readErr := ioutil.ReadAll(response.Body)
+		if closeErr := response.Body.Close(); closeErr != nil {
+			fmt.Println(closeErr)
+		}
+		if readErr != nil {
+			return response, readErr
+		}
+		// Restore the body so callers calling CheckResponse still see it.
+		response.Body = ioutil.NopCloser(bytes.NewReader(body))
 
-		errorList := map[string]interface{}{}
-		if err := json.NewDecoder(response.Body).Decode(&errorList); err != nil {
-			return response, err
+		if response.StatusCode == http.StatusBadRequest {
+			errorList := map[string]interface{}{}
+			if err := json.Unmarshal(body, &errorList); err == nil {
+				errorString := "Errors:"
+				for k, v := range errorList {
+					errorString = fmt.Sprintf("%s\n- %s: %+v", errorString, k, v)
+				}
+
+				return response, errors.New(errorString)
+			}
 		}
 
-		errorString = "Errors:"
-		for k, v := range errorList {
-			errorString = fmt.Sprintf("%s\n- %s: %+v", errorString, k, v)
-		}
-
-		return response, errors.New(errorString)
+		return response, HTTPError(response.StatusCode, body)
 	}
 
 	// If there is no response body, or if the response is of type `No Content` bypass the decode process.


### PR DESCRIPTION
The provider replaced any client creation error with a fixed "check the hostname, username and password" string, hiding what AWX returned. Report the HTTP status code and the response body. Stop printing the request headers, which leaked credentials