### PR TITLE
fix: store inventory_id and node template ids in state

### DIFF
--- a/internal/awx/resource_job_template.go
+++ b/internal/awx/resource_job_template.go
@@ -468,7 +468,12 @@ func setJobTemplateResourceData(d *schema.ResourceData, r *awx.JobTemplate) *sch
 	if err := d.Set("host_config_key", r.HostConfigKey); err != nil {
 		fmt.Println("Error setting host_config_key", err)
 	}
-	if err := d.Set("inventory_id", r.Inventory); err != nil {
+	// AWX returns a null inventory for templates that prompt for one on launch
+	inventoryID := ""
+	if r.Inventory != 0 {
+		inventoryID = strconv.Itoa(r.Inventory)
+	}
+	if err := d.Set("inventory_id", inventoryID); err != nil {
 		fmt.Println("Error setting inventory_id", err)
 	}
 	if err := d.Set("job_tags", r.JobTags); err != nil {

--- a/internal/awx/resource_workflow_job_template_node.go
+++ b/internal/awx/resource_workflow_job_template_node.go
@@ -195,7 +195,7 @@ func setWorkflowJobTemplateNodeResourceData(d *schema.ResourceData, r *awx.Workf
 	if err := d.Set("extra_data", r.ExtraData); err != nil {
 		fmt.Println("Error setting extra_data", err)
 	}
-	if err := d.Set("inventory_id", strconv.Itoa(r.Inventory)); err != nil {
+	if err := d.Set("inventory_id", r.Inventory); err != nil {
 		fmt.Println("Error setting inventory_id", err)
 	}
 	if err := d.Set("scm_branch", r.ScmBranch); err != nil {
@@ -220,10 +220,10 @@ func setWorkflowJobTemplateNodeResourceData(d *schema.ResourceData, r *awx.Workf
 		fmt.Println("Error setting verbosity", err)
 	}
 
-	if err := d.Set("workflow_job_template_id", strconv.Itoa(r.WorkflowJobTemplate)); err != nil {
+	if err := d.Set("workflow_job_template_id", r.WorkflowJobTemplate); err != nil {
 		fmt.Println("Error setting workflow_job_template_id", err)
 	}
-	if err := d.Set("unified_job_template_id", strconv.Itoa(r.UnifiedJobTemplate)); err != nil {
+	if err := d.Set("unified_job_template_id", r.UnifiedJobTemplate); err != nil {
 		fmt.Println("Error setting unified_job_template_id", err)
 	}
 	if err := d.Set("all_parents_must_converge", r.AllParentsMustConverge); err != nil {


### PR DESCRIPTION
awx_job_template declares inventory_id as a string but the read handed it the integer AWX returns, while awx_workflow_job_template_node declares inventory_id, workflow_job_template_id and unified_job_template_id as integers and the read handed them strings. Terraform rejected all four writes with "expected type 'string', got unconvertible type 'int'" and its mirror image, printed the error to the provider output and left the attributes at their zero value.

Importing a job template therefore never recovered its inventory, and importing a workflow node came back with no inventory, no parent workflow and no unified job template, the last two being required attributes. Editing any of these in AWX raised no drift either, because state held nothing to compare against.

Each read now passes the type its schema declares. A job template that prompts for its inventory on launch reports an empty inventory_id rather than "0", AWX returning null there and Go decoding that as zero.