### PR TITLE
feat: add limit support to job schedules

### DIFF
--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -43,6 +43,7 @@ resource "awx_schedule" "default" {
   name                    = "schedule-test"
   rrule                   = "DTSTART;TZID=Europe/Paris:20211214T120000 RRULE:INTERVAL=1;FREQ=DAILY"
   unified_job_template_id = awx_job_template.example.id
+  limit                   = "webservers"
   extra_data              = <<EOL
 
 organization_name: testorg
@@ -65,6 +66,7 @@ EOL
 - `enabled` (Boolean) Enable or disable the schedule
 - `extra_data` (String) Extra data to be pass for the schedule (JSON format)
 - `inventory` (Number) The ID of the Inventory to be used for the schedule
+- `limit` (String) Host pattern applied as a prompt, assuming the job template prompts for a limit
 
 ### Read-Only
 

--- a/docs/resources/workflow_job_template_schedule.md
+++ b/docs/resources/workflow_job_template_schedule.md
@@ -32,6 +32,7 @@ resource "awx_workflow_job_template_schedule" "default" {
   workflow_job_template_id = awx_workflow_job_template.example.id
   name                     = "schedule-test"
   rrule                    = "DTSTART;TZID=Europe/Paris:20211214T120000 RRULE:INTERVAL=1;FREQ=DAILY"
+  limit                    = "webservers"
   extra_data               = <<EOL
 organization_name: testorg
 EOL
@@ -53,6 +54,7 @@ EOL
 - `enabled` (Boolean) Whether the schedule is enabled or not
 - `extra_data` (String) Extra data to be pass for the schedule (YAML format)
 - `inventory` (String) Inventory applied as a prompt, assuming job template prompts for inventory (id, default=``)
+- `limit` (String) Host pattern applied as a prompt, assuming the workflow job template prompts for a limit
 - `unified_job_template_id` (Number) The unified job template id for this schedule
 
 ### Read-Only

--- a/examples/resources/awx_schedule/resource.tf
+++ b/examples/resources/awx_schedule/resource.tf
@@ -28,6 +28,7 @@ resource "awx_schedule" "default" {
   name                    = "schedule-test"
   rrule                   = "DTSTART;TZID=Europe/Paris:20211214T120000 RRULE:INTERVAL=1;FREQ=DAILY"
   unified_job_template_id = awx_job_template.example.id
+  limit                   = "webservers"
   extra_data              = <<EOL
 
 organization_name: testorg

--- a/examples/resources/awx_workflow_job_template_schedule/resource.tf
+++ b/examples/resources/awx_workflow_job_template_schedule/resource.tf
@@ -17,6 +17,7 @@ resource "awx_workflow_job_template_schedule" "default" {
   workflow_job_template_id = awx_workflow_job_template.example.id
   name                     = "schedule-test"
   rrule                    = "DTSTART;TZID=Europe/Paris:20211214T120000 RRULE:INTERVAL=1;FREQ=DAILY"
+  limit                    = "webservers"
   extra_data               = <<EOL
 organization_name: testorg
 EOL

--- a/internal/awx/resource_schedule.go
+++ b/internal/awx/resource_schedule.go
@@ -52,6 +52,12 @@ func resourceSchedule() *schema.Resource {
 				Optional:    true,
 				Description: "The ID of the Inventory to be used for the schedule",
 			},
+			"limit": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "Host pattern applied as a prompt, assuming the job template prompts for a limit",
+			},
 			"extra_data": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -77,6 +83,7 @@ func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, m inter
 		"unified_job_template": d.Get("unified_job_template_id").(int),
 		"description":          d.Get("description").(string),
 		"enabled":              d.Get("enabled").(bool),
+		"limit":                d.Get("limit").(string),
 		"extra_data":           utils.UnmarshalJSON(d.Get("extra_data").(string)),
 	}
 	if _, ok := d.GetOk("inventory"); ok {
@@ -116,6 +123,7 @@ func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		"unified_job_template": d.Get("unified_job_template_id").(int),
 		"description":          d.Get("description").(string),
 		"enabled":              d.Get("enabled").(bool),
+		"limit":                d.Get("limit").(string),
 		"extra_data":           utils.UnmarshalJSON(d.Get("extra_data").(string)),
 	}
 	if _, ok := d.GetOk("inventory"); ok {
@@ -177,6 +185,9 @@ func setScheduleResourceData(d *schema.ResourceData, r *awx.Schedule) *schema.Re
 	}
 	if err := d.Set("inventory", r.Inventory); err != nil {
 		fmt.Println("Error setting inventory", err)
+	}
+	if err := d.Set("limit", r.Limit); err != nil {
+		fmt.Println("Error setting limit", err)
 	}
 	if err := d.Set("extra_data", utils.MarshalJSON(r.ExtraData)); err != nil {
 		fmt.Println("Error setting extra_data", err)

--- a/internal/awx/resource_workflow_job_template_schedule.go
+++ b/internal/awx/resource_workflow_job_template_schedule.go
@@ -57,6 +57,12 @@ func resourceWorkflowJobTemplateSchedule() *schema.Resource {
 				Optional:    true,
 				Description: "Inventory applied as a prompt, assuming job template prompts for inventory (id, default=``)",
 			},
+			"limit": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "Host pattern applied as a prompt, assuming the workflow job template prompts for a limit",
+			},
 			"extra_data": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -81,6 +87,7 @@ func resourceWorkflowJobTemplateScheduleCreate(ctx context.Context, d *schema.Re
 		"description": d.Get("description").(string),
 		"enabled":     d.Get("enabled").(bool),
 		"inventory":   utils.AtoiDefault(d.Get("inventory").(string), nil),
+		"limit":       d.Get("limit").(string),
 		"extra_data":  utils.UnmarshalYAML(d.Get("extra_data").(string)),
 	}, map[string]string{})
 	if err != nil {

--- a/tools/goawx/types.go
+++ b/tools/goawx/types.go
@@ -911,6 +911,7 @@ type Schedule struct {
 	Enabled            bool                   `json:"enabled"`
 	UnifiedJobTemplate int                    `json:"unified_job_template"`
 	Inventory          int                    `json:"inventory"`
+	Limit              string                 `json:"limit"`
 	ExtraData          map[string]interface{} `json:"extra_data"`
 }
 


### PR DESCRIPTION
Expose the AWX schedule `limit` field as an optional attribute on `awx_schedule` and `awx_workflow_job_template_schedule`, so a host pattern can be applied as a prompt when the job template asks for one.